### PR TITLE
Remove Lombok @SneakyThrows from connectNow() and disconnectNow().

### DIFF
--- a/NcsClient/src/main/java/com/github/terefang/ncs/client/NcsClientService.java
+++ b/NcsClient/src/main/java/com/github/terefang/ncs/client/NcsClientService.java
@@ -58,8 +58,7 @@ public interface NcsClientService
     /**
      * connects to the server and whaits for completion
      */
-    @SneakyThrows
-    default void connectNow()
+    default void connectNow() throws Exception
     {
         ((ChannelFuture)this.connect()).sync();
     }
@@ -67,8 +66,7 @@ public interface NcsClientService
     /**
      * disconnects from the server and whaits for completion
      */
-    @SneakyThrows
-    default void disconnectNow()
+    default void disconnectNow() throws Exception
     {
         ((ChannelFuture)this.disconnect()).sync();
     }


### PR DESCRIPTION
I think the library user should be able to handle these exceptions inside their project. Currently if the exception fires, it won't be handled in the user project and will hang the thread.

This should fix that.